### PR TITLE
order ownership on status subscribe stream

### DIFF
--- a/api/src/contract.ts
+++ b/api/src/contract.ts
@@ -423,7 +423,8 @@ export const contract = oc.router({
       tags: ["Orders"],
     })
     .input(z.object({ sessionId: z.string() }))
-    .output(eventIterator(OrderStatusEventSchema)),
+    .output(eventIterator(OrderStatusEventSchema))
+    .errors({ FORBIDDEN, UNAUTHORIZED }),
 
   getAllOrders: oc
     .route({

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -1032,7 +1032,7 @@ export default createPlugin({
       subscribeOrderStatus: builder.subscribeOrderStatus
         .use(requireAuth)
         .handler(
-        async function* ({ input, signal }) {
+        async function* ({ input, signal, context, errors }) {
           const TERMINAL_STATUSES = [
             "shipped",
             "delivered",
@@ -1059,6 +1059,13 @@ export default createPlugin({
             if (!order) {
               await new Promise((r) => setTimeout(r, POLL_INTERVAL));
               continue;
+            }
+
+            if (order.userId !== context.nearAccountId) {
+              throw errors.FORBIDDEN({
+                message: "You do not have permission to access this order",
+                data: { action: "read" },
+              });
             }
 
             const currentTrackingJson = JSON.stringify(


### PR DESCRIPTION
Summary: Non-owners could subscribe to another user's order status SSE stream using only a checkout sessionId. Ownership is now enforced the same way as get-by-session.

Test plan:
- As userB, GET /api/orders/status/subscribe/{sessionId} for someone else's session → FORBIDDEN
- As the order owner, the same subscribe call still streams status updates

Video for ref: 
https://github.com/user-attachments/assets/90b6a53a-7cc3-4e70-aebd-82d579d5c059
