### PR TITLE
fix: prevent access to unlisted products

### DIFF
--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -484,11 +484,18 @@ export default createPlugin({
         };
       }),
 
-      getProduct: builder.getProduct.handler(async ({ input, errors }) => {
+      getProduct: builder.getProduct.handler(async ({ input, errors, context }) => {
+        const isAdmin = context?.user?.role === "admin";
         const exit = await managedRuntime.runPromiseExit(
           Effect.gen(function* () {
             const service = yield* ProductService;
-            return yield* service.getProduct(input.id);
+            const result = yield* service.getProduct(input.id);
+            if (!result.product.listed && !isAdmin) {
+              return yield* Effect.fail(
+                new Error(`Product not found: ${input.id}`),
+              );
+            }
+            return result;
           }),
         );
 
@@ -502,7 +509,7 @@ export default createPlugin({
             error.message.includes("Product not found")
           ) {
             throw errors.NOT_FOUND({
-              message: error.message,
+              message: "This product is no longer available.",
               data: { resource: "product", resourceId: input.id },
             });
           }

--- a/api/src/services/checkout.ts
+++ b/api/src/services/checkout.ts
@@ -356,7 +356,7 @@ export const CheckoutServiceLive = (runtime: MarketplaceRuntime) =>
 
             for (const item of items) {
               const product = yield* productStore.find(item.productId);
-              if (!product) {
+              if (!product || !product.listed) {
                 return yield* Effect.fail(
                   new Error(`Product not found: ${item.productId}`),
                 );
@@ -623,7 +623,7 @@ export const CheckoutServiceLive = (runtime: MarketplaceRuntime) =>
 
             for (const item of items) {
               const product = yield* productStore.find(item.productId);
-              if (!product) {
+              if (!product || !product.listed) {
                 return yield* Effect.fail(
                   new Error(`Product not found: ${item.productId}`),
                 );

--- a/ui/src/routes/_marketplace/products/$productId.tsx
+++ b/ui/src/routes/_marketplace/products/$productId.tsx
@@ -85,6 +85,35 @@ function formatFeeType(type: string): string {
   }
 }
 
+function getProductLoadErrorCopy(error?: unknown) {
+  const err = error as {
+    message?: string;
+    code?: string;
+    status?: number;
+  } | null;
+  const message = err?.message ?? "";
+  const isNotFound =
+    err?.status === 404 ||
+    err?.code === "NOT_FOUND" ||
+    /product not found/i.test(message) ||
+    /no longer available/i.test(message);
+
+  if (isNotFound) {
+    return {
+      title: "Product Not Available",
+      description: "This product is no longer available.",
+      showRetry: false,
+    };
+  }
+
+  return {
+    title: "Unable to Load Product",
+    description:
+      "Failed to load product details. Please check your connection and try again.",
+    showRetry: true,
+  };
+}
+
 export const Route = createFileRoute("/_marketplace/products/$productId")({
   pendingComponent: LoadingSpinner,
   loader: async ({ params, context }) => {
@@ -95,7 +124,16 @@ export const Route = createFileRoute("/_marketplace/products/$productId")({
       const data = await apiClient.getProduct({ id: params.productId });
       return { data: { product: data.product }, siteUrl, assetsUrl };
     } catch (error) {
-      return { error: error as Error, data: null, siteUrl, assetsUrl };
+      const copy = getProductLoadErrorCopy(error);
+      // Never pass raw API text (e.g. slug) through to the UI.
+      return {
+        error: new Error(copy.description),
+        data: null,
+        siteUrl,
+        assetsUrl,
+        errorTitle: copy.title,
+        showRetry: copy.showRetry,
+      };
     }
   },
   head: ({ loaderData }) => {
@@ -130,20 +168,20 @@ export const Route = createFileRoute("/_marketplace/products/$productId")({
   },
   errorComponent: ({ error }) => {
     const router = useRouter();
+    const copy = getProductLoadErrorCopy(error);
 
     return (
       <div className="min-h-screen flex items-center justify-center p-4">
         <div className="max-w-md text-center space-y-4">
           <div className="text-destructive">
             <AlertCircle className="h-12 w-12 mx-auto mb-4" />
-            <h2 className="text-xl font-semibold">Unable to Load Product</h2>
+            <h2 className="text-xl font-semibold">{copy.title}</h2>
           </div>
-          <p className="text-muted-foreground">
-            {error.message ||
-              "Failed to load product details. Please check your connection and try again."}
-          </p>
+          <p className="text-muted-foreground">{copy.description}</p>
           <div className="flex gap-3 justify-center">
-            <Button onClick={() => router.invalidate()}>Try Again</Button>
+            {copy.showRetry && (
+              <Button onClick={() => router.invalidate()}>Try Again</Button>
+            )}
             <Button
               variant="outline"
               onClick={() => router.navigate({ to: "/" })}
@@ -169,19 +207,29 @@ function ProductDetailPage() {
   const loaderData = Route.useLoaderData();
 
   if (loaderData.error || !loaderData.data) {
+    const copy =
+      "errorTitle" in loaderData && loaderData.errorTitle
+        ? {
+            title: loaderData.errorTitle,
+            description:
+              loaderData.error?.message ||
+              "This product is no longer available.",
+            showRetry: Boolean(loaderData.showRetry),
+          }
+        : getProductLoadErrorCopy(loaderData.error);
+
     return (
       <div className="min-h-screen flex items-center justify-center p-4">
         <div className="max-w-md text-center space-y-4">
           <div className="text-destructive">
             <AlertCircle className="h-12 w-12 mx-auto mb-4" />
-            <h2 className="text-xl font-semibold">Unable to Load Product</h2>
+            <h2 className="text-xl font-semibold">{copy.title}</h2>
           </div>
-          <p className="text-muted-foreground">
-            {loaderData.error?.message ||
-              "Failed to load product details. Please check your connection and try again."}
-          </p>
+          <p className="text-muted-foreground">{copy.description}</p>
           <div className="flex gap-3 justify-center">
-            <Button onClick={() => window.location.reload()}>Try Again</Button>
+            {copy.showRetry && (
+              <Button onClick={() => window.location.reload()}>Try Again</Button>
+            )}
             <Link to="/">
               <Button variant="outline">Go Home</Button>
             </Link>


### PR DESCRIPTION
Fixes #196.

Summary:
Prevents customers from accessing unlisted products through direct URLs.
Returns a customer-friendly “Product Not Available” page without exposing raw API errors.
Keeps unlisted products accessible to admins for management.

Testing:
Delisted a product and confirmed it disappeared from the storefront.
Verified its direct URL displayed the unavailable-product message.
Relisted the product and confirmed the page became accessible again.