### PR TITLE
Fix order selection persisting incorrectly after filtering

### DIFF
--- a/ui/src/components/ui/data-table.tsx
+++ b/ui/src/components/ui/data-table.tsx
@@ -8,6 +8,7 @@ import {
   type SortingState,
   useReactTable,
   type RowSelectionState,
+  type Row,
 } from '@tanstack/react-table';
 import { ChevronLeft, ChevronRight, ChevronsLeft, ChevronsRight } from 'lucide-react';
 
@@ -34,6 +35,7 @@ interface DataTableProps<TData, TValue> {
   searchValue?: string;
   rowSelection?: RowSelectionState;
   onRowSelectionChange?: (updaterOrValue: RowSelectionState | ((old: RowSelectionState) => RowSelectionState)) => void;
+  getRowId?: (originalRow: TData, index: number, parent?: Row<TData>) => string;
 }
 
 export function DataTable<TData, TValue>({
@@ -41,6 +43,7 @@ export function DataTable<TData, TValue>({
   data,
   rowSelection,
   onRowSelectionChange,
+  getRowId,
 }: DataTableProps<TData, TValue>) {
   const [sorting, setSorting] = useState<SortingState>([]);
 
@@ -52,6 +55,7 @@ export function DataTable<TData, TValue>({
     onSortingChange: setSorting,
     getSortedRowModel: getSortedRowModel(),
     onRowSelectionChange: onRowSelectionChange,
+    getRowId,
     state: {
       sorting,
       rowSelection: rowSelection ?? {},

--- a/ui/src/routes/_marketplace/_authenticated/_admin/dashboard/orders.tsx
+++ b/ui/src/routes/_marketplace/_authenticated/_admin/dashboard/orders.tsx
@@ -455,9 +455,28 @@ function AdminOrdersPage() {
   }, [filteredOrders, routeSearch.orderId]);
 
   const selectedOrders = useMemo(() => {
-    const selectedIndices = Object.keys(rowSelection).filter(key => rowSelection[key]);
-    return selectedIndices.map(index => filteredOrders[parseInt(index)]).filter(Boolean);
+    const ordersById = new Map(filteredOrders.map((order) => [order.id, order]));
+    return Object.keys(rowSelection)
+      .filter((orderId) => rowSelection[orderId])
+      .map((orderId) => ordersById.get(orderId))
+      .filter((order): order is Order => Boolean(order));
   }, [rowSelection, filteredOrders]);
+
+  useEffect(() => {
+    const visibleOrderIds = new Set(filteredOrders.map((order) => order.id));
+
+    setRowSelection((currentSelection) => {
+      const visibleSelection = Object.fromEntries(
+        Object.entries(currentSelection).filter(
+          ([orderId, isSelected]) => isSelected && visibleOrderIds.has(orderId),
+        ),
+      );
+
+      return Object.keys(visibleSelection).length === Object.keys(currentSelection).length
+        ? currentSelection
+        : visibleSelection;
+    });
+  }, [filteredOrders]);
 
   const handleDeleteClick = () => {
     if (selectedOrders.length === 0) return;
@@ -772,6 +791,7 @@ function AdminOrdersPage() {
               data={filteredOrders}
               rowSelection={rowSelection}
               onRowSelectionChange={setRowSelection}
+              getRowId={(order) => order.id}
             />
           </div>
 


### PR DESCRIPTION
## Fix order selection changing after filtering

### Problem

Selecting an order and then applying a filter could incorrectly transfer the selection to another order that occupied the same row position in the filtered table.

This happened because table row selection was tracked using row indexes rather than stable order IDs. As a result, an admin could unintentionally delete the wrong order.

### Changes made

- Updated the shared `DataTable` component to support a custom stable row ID through `getRowId`.
- Configured the admin orders table to use `order.id` as its row ID.
- Updated selected-order lookup logic to resolve selections by order ID instead of filtered row index.
- Added selection cleanup when the visible filtered order list changes:
  - If a selected order is no longer present after filtering, its selection is removed.
  - The selection therefore cannot persist onto a different order.

### Result

Order selection is now tied to the original order ID.

When filtering:
- Selected orders that remain visible stay selected.
- Selected orders that disappear are automatically deselected.
- No other order can inherit the selection due to a matching row position.

### Validation

- Ran the UI test suite successfully: `10 tests passed`.
- Ran `git diff --check` successfully.
- Note: project-wide typecheck is currently blocked by an unrelated existing error in `ui/src/routes/_marketplace/_authenticated/checkout.tsx`.