### PR TITLE
Fix/homepage carousel empty state

### DIFF
--- a/ui/src/components/ui/data-table.tsx
+++ b/ui/src/components/ui/data-table.tsx
@@ -8,6 +8,7 @@ import {
   type SortingState,
   useReactTable,
   type RowSelectionState,
+  type Row,
 } from '@tanstack/react-table';
 import { ChevronLeft, ChevronRight, ChevronsLeft, ChevronsRight } from 'lucide-react';
 
@@ -34,6 +35,7 @@ interface DataTableProps<TData, TValue> {
   searchValue?: string;
   rowSelection?: RowSelectionState;
   onRowSelectionChange?: (updaterOrValue: RowSelectionState | ((old: RowSelectionState) => RowSelectionState)) => void;
+  getRowId?: (originalRow: TData, index: number, parent?: Row<TData>) => string;
 }
 
 export function DataTable<TData, TValue>({
@@ -41,6 +43,7 @@ export function DataTable<TData, TValue>({
   data,
   rowSelection,
   onRowSelectionChange,
+  getRowId,
 }: DataTableProps<TData, TValue>) {
   const [sorting, setSorting] = useState<SortingState>([]);
 
@@ -52,6 +55,7 @@ export function DataTable<TData, TValue>({
     onSortingChange: setSorting,
     getSortedRowModel: getSortedRowModel(),
     onRowSelectionChange: onRowSelectionChange,
+    getRowId,
     state: {
       sorting,
       rowSelection: rowSelection ?? {},

--- a/ui/src/routes/_marketplace/_authenticated/_admin/dashboard/orders.tsx
+++ b/ui/src/routes/_marketplace/_authenticated/_admin/dashboard/orders.tsx
@@ -455,9 +455,28 @@ function AdminOrdersPage() {
   }, [filteredOrders, routeSearch.orderId]);
 
   const selectedOrders = useMemo(() => {
-    const selectedIndices = Object.keys(rowSelection).filter(key => rowSelection[key]);
-    return selectedIndices.map(index => filteredOrders[parseInt(index)]).filter(Boolean);
+    const ordersById = new Map(filteredOrders.map((order) => [order.id, order]));
+    return Object.keys(rowSelection)
+      .filter((orderId) => rowSelection[orderId])
+      .map((orderId) => ordersById.get(orderId))
+      .filter((order): order is Order => Boolean(order));
   }, [rowSelection, filteredOrders]);
+
+  useEffect(() => {
+    const visibleOrderIds = new Set(filteredOrders.map((order) => order.id));
+
+    setRowSelection((currentSelection) => {
+      const visibleSelection = Object.fromEntries(
+        Object.entries(currentSelection).filter(
+          ([orderId, isSelected]) => isSelected && visibleOrderIds.has(orderId),
+        ),
+      );
+
+      return Object.keys(visibleSelection).length === Object.keys(currentSelection).length
+        ? currentSelection
+        : visibleSelection;
+    });
+  }, [filteredOrders]);
 
   const handleDeleteClick = () => {
     if (selectedOrders.length === 0) return;
@@ -772,6 +791,7 @@ function AdminOrdersPage() {
               data={filteredOrders}
               rowSelection={rowSelection}
               onRowSelectionChange={setRowSelection}
+              getRowId={(order) => order.id}
             />
           </div>
 

--- a/ui/src/routes/_marketplace/index.tsx
+++ b/ui/src/routes/_marketplace/index.tsx
@@ -214,7 +214,7 @@ function MarketplaceHome() {
   return (
     <PageTransition className="m-0 p-0 relative">
       {activeSlide && <VideoBackground position="absolute" height="calc(100vh - 80px)" />}
-      {!activeSlide && (isCollectionsLoading || collections.length === 0) && <VideoBackground position="absolute" height="calc(100vh - 80px)" />}
+      {!activeSlide && isCollectionsLoading && <VideoBackground position="absolute" height="calc(100vh - 80px)" />}
       {activeSlide && (
       <section className="pt-24 md:pt-32 relative z-10 min-h-[calc(100vh-120px)] flex items-center">
         <div className="w-full max-w-[1408px] mx-auto px-4 md:px-8 lg:px-16">
@@ -400,7 +400,7 @@ function MarketplaceHome() {
       </section>
       )}
 
-      {!activeSlide && (isCollectionsLoading || collections.length === 0) && <MarketplaceSkeletonLoader />}
+      {!activeSlide && isCollectionsLoading && <MarketplaceSkeletonLoader />}
 
       {activeSlide && (
             <div className="lg:hidden rounded-2xl bg-background/60 backdrop-blur-sm border border-border/60 px-4 md:px-6 py-4 md:py-6 relative z-10 mx-4 md:mx-8 -mt-4 md:mt-0 mb-6 md:mb-8">


### PR DESCRIPTION
### Problem

When every collection has **Show in carousel** disabled, the homepage receives an empty carousel collection list.

The homepage incorrectly treated this completed empty response as a loading state, causing the carousel skeleton to remain visible indefinitely.

### Changes made

- Updated the homepage carousel conditions to show the video background and skeleton only while carousel collections are actively loading.
- Removed the condition that treated an empty collection list as loading.
- When carousel loading completes with no enabled collections, the homepage now skips the collection hero area and continues to the normal product content.

### Result

- The loading skeleton is displayed only during the actual data request.
- If no collections are enabled for the carousel, shoppers no longer see an endless loading state.
- The homepage instead shows its existing content and empty states as applicable.

<img width="1497" height="994" alt="image" src="https://github.com/user-attachments/assets/f2f0adf4-c315-4a9c-90e7-3c49a9bd844f" />


### Empty-state behavior

No dedicated carousel empty state was added because carousel visibility is an admin configuration setting. Skipping the carousel is preferable to showing shoppers an admin-focused message.

If there are no featured products either, the existing product empty state is shown:
> No Products Found  
> There are currently no products available in the marketplace.

### Validation

- Ran `bun run test`
- All UI tests pass: **10 tests**
- Ran `git diff --check` successfully