### PR TITLE
fix: propagate and sanitize provider quote errors on checkout (#96)

### DIFF
--- a/.changeset/solid-cameras-start.md
+++ b/.changeset/solid-cameras-start.md
@@ -1,0 +1,7 @@
+---
+"host": patch
+"api": patch
+"ui": patch
+---
+
+Fix provider quote errors not reaching frontend and sanitize debug prefixes (#96)

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -888,6 +888,15 @@ export default createPlugin({
                 });
               }
 
+              if (error.code === "QUOTE_FAILED") {
+                throw new ORPCError("BAD_REQUEST", {
+                  message:
+                    error.cause instanceof Error
+                      ? error.cause.message
+                      : "Shipping is not available to this destination",
+                });
+              }
+
               console.error("[createCheckout] Checkout failed:", error.message);
               if (error.cause)
                 console.error("[createCheckout] Cause:", error.cause);
@@ -924,11 +933,15 @@ export default createPlugin({
           if (error instanceof ORPCError) {
             throw error;
           }
+          // Extract user-friendly message from CheckoutError cause
+          let message = "Failed to calculate shipping";
+          if (error instanceof CheckoutError && error.cause instanceof Error) {
+            message = error.cause.message;
+          } else if (error instanceof Error) {
+            message = error.message;
+          }
           throw new ORPCError("BAD_REQUEST", {
-            message:
-              error instanceof Error
-                ? error.message
-                : "Failed to calculate shipping",
+            message,
           });
         }
 

--- a/host/src/program.ts
+++ b/host/src/program.ts
@@ -203,7 +203,6 @@ function setupApiRoutes(
 		interceptors: [
 			onError((error: unknown) => {
 				formatORPCError(error);
-				throw error;
 			}),
 		],
 	});
@@ -225,7 +224,6 @@ function setupApiRoutes(
 		interceptors: [
 			onError((error: unknown) => {
 				formatORPCError(error);
-				throw error;
 			}),
 		],
 	});

--- a/ui/src/routes/_marketplace/_authenticated/checkout.tsx
+++ b/ui/src/routes/_marketplace/_authenticated/checkout.tsx
@@ -59,6 +59,12 @@ export const Route = createFileRoute("/_marketplace/_authenticated/checkout")({
 type ShippingQuote = Awaited<ReturnType<typeof apiClient.quote>>;
 type ShippingAddress = Parameters<typeof apiClient.quote>[0]['shippingAddress'];
 
+function formatCheckoutErrorMessage(message?: string): string {
+  if (!message) return '';
+  const cleaned = message.replace(/^Checkout\s+[A-Z_]+(?:\s*\[[^\]]*\])?:\s*/i, '').trim();
+  return cleaned || message;
+}
+
 function CheckoutPage() {
   const { cartItems, subtotal } = useCart();
   const cartStoreItems = useCartStore((state) => state.items);
@@ -204,9 +210,10 @@ function CheckoutPage() {
       toast.success('Shipping calculated successfully');
     },
     onError: (error: Error) => {
-      setShippingError(error.message);
+      const friendlyMessage = formatCheckoutErrorMessage(error.message);
+      setShippingError(friendlyMessage);
       setShippingQuote(null);
-      toast.error(error.message || 'Failed to calculate shipping');
+      toast.error(friendlyMessage || 'Failed to calculate shipping');
     },
   });
 
@@ -245,7 +252,8 @@ function CheckoutPage() {
       }
     },
     onError: (error: Error) => {
-      toast.error(error.message || 'Order Failed, please contact support (merch@near.foundation)');
+      const friendlyMessage = formatCheckoutErrorMessage(error.message);
+      toast.error(friendlyMessage || 'Order Failed, please contact support (merch@near.foundation)');
     },
   });
 


### PR DESCRIPTION
Hey, I was able to reproduce the issue and submitted a fix.

### Summary of Fix:
- **`host`**: Removed `throw error;` in `onError` interceptors so oRPC properly returns 400 responses instead of triggering Hono's 500 error handler.
- **`api`**: Extracted clean user-facing error messages from `CheckoutError.cause` for quote and checkout handlers.
- **`ui`**: Sanitized raw provider/debug prefixes so users only see clean destination error messages.

### Verification:
- **Before:** Showed generic 500 errors or raw debug tags (`Checkout QUOTE_FAILED [provider=lulu]: ...`).
- **After:** Cleanly displays `Shipping is not available to this destination`.

### Before fixes
<img width="903" height="402" alt="Screenshot 2026-09-10 220721" src="https://github.com/user-attachments/assets/c83dcdff-b5ec-4652-961d-cb2763acdd07" />

### After fixes 
<img width="1672" height="845" alt="image" src="https://github.com/user-attachments/assets/9caf1b3f-9ad1-479c-b793-ce3e1c00d664" />
